### PR TITLE
adding cloudinary storage for images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "font-awesome-sass", "~> 6.1"
 gem "simple_form", github: "heartcombo/simple_form"
 gem "sassc-rails"
 gem "cloudinary"
+gem "activestorage-cloudinary-service"
 
 group :development, :test do
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       activerecord (= 7.1.3.4)
       activesupport (= 7.1.3.4)
       marcel (~> 1.0)
+    activestorage-cloudinary-service (0.2.3)
     activesupport (7.1.3.4)
       base64
       bigdecimal
@@ -306,6 +307,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activestorage-cloudinary-service
   autoprefixer-rails
   bootsnap
   bootstrap (~> 5.2)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,12 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+cloudinary:
+  service: Cloudinary
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,10 +41,20 @@ products = [
   { name: 'Poseidon', price: 60.0, description: 'Press on avec motif de Poseidon', image_files: ['poseidon_1.jpeg'] }
 ]
 
+# products.each do |product_data|
+#   product = Product.create(name: product_data[:name], price: product_data[:price], description: product_data[:description])
+#   product_data[:image_files].each do |image_file|
+#     image_path = Rails.root.join('app', 'assets', 'images', image_file)
+#     product.images.attach(io: File.open(image_path), filename: image_file) if File.exist?(image_path)
+#   end
+# end
+
 products.each do |product_data|
   product = Product.create(name: product_data[:name], price: product_data[:price], description: product_data[:description])
   product_data[:image_files].each do |image_file|
     image_path = Rails.root.join('app', 'assets', 'images', image_file)
-    product.images.attach(io: File.open(image_path), filename: image_file) if File.exist?(image_path)
+    if File.exist?(image_path)
+      product.images.attach(io: File.open(image_path), filename: image_file, content_type: 'image/jpeg')
+    end
   end
 end


### PR DESCRIPTION
Due to Product implementation having images taken from the assets, we needed to allow assets loading on the project as it was throwing an error
We then enabled Cloudinary storage for Prod so that required some config changes